### PR TITLE
Pin rio tiler to `6.2.3.post1`

### DIFF
--- a/raster_api/runtime/setup.py
+++ b/raster_api/runtime/setup.py
@@ -14,6 +14,7 @@ inst_reqs = [
     "starlette-cramjam>=0.3,<0.4",
     "aws_xray_sdk>=2.6.0,<3",
     "aws-lambda-powertools>=1.18.0",
+    "rio-tiler==6.2.3.post1",
 ]
 
 extra_reqs = {


### PR DESCRIPTION
Fix for low output resolution introduced by 6.2.4 while still keeping area weighted stats