### PR TITLE
Change STAC API title to ghgc-stac

### DIFF
--- a/stac_api/runtime/src/config.py
+++ b/stac_api/runtime/src/config.py
@@ -54,7 +54,7 @@ def get_secret_dict(secret_name: str):
 class _ApiSettings(pydantic.BaseSettings):
     """API settings"""
 
-    name: str = "veda-stac"
+    name: str = "ghgc-stac"
     cors_origins: str = "*"
     cachecontrol: str = "public, max-age=3600"
     debug: bool = False


### PR DESCRIPTION
Title was `veda-stac`

Fixes https://github.com/NASA-IMPACT/veda-config-ghg/issues/157