### PR TITLE
fix(stac-api): do not overwrite api_gateway_base_path in stac-api handler

### DIFF
--- a/config.py
+++ b/config.py
@@ -71,6 +71,19 @@ class vedaAppSettings(BaseSettings):
         """Force lowercase stage name"""
         return self.stage.lower()
 
+    def get_stac_catalog_url(self) -> Optional[str]:
+        """Infer stac catalog url based on whether the app is configured to deploy the catalog to a custom subdomain or to a cloudfront route"""
+        if self.veda_custom_host and self.veda_stac_root_path:
+            return f"https://{veda_app_settings.veda_custom_host}{veda_app_settings.veda_stac_root_path}"
+        if (
+            self.veda_domain_create_custom_subdomains
+            and self.veda_domain_hosted_zone_name
+        ):
+            return (
+                f"https://{self.stage.lower()}-stac.{self.veda_domain_hosted_zone_name}"
+            )
+        return None
+
     class Config:
         """model config."""
 

--- a/stac_api/runtime/handler.py
+++ b/stac_api/runtime/handler.py
@@ -12,7 +12,7 @@ settings = ApiSettings()
 logging.getLogger("mangum.lifespan").setLevel(logging.ERROR)
 logging.getLogger("mangum.http").setLevel(logging.ERROR)
 
-handler = Mangum(app, lifespan="auto", api_gateway_base_path=app.root_path)
+handler = Mangum(app, lifespan="auto")
 
 # Add tracing
 handler.__name__ = "handler"  # tracer requires __name__ to be set


### PR DESCRIPTION
# What
- Fix trailing slash and next links bug in stac-api
- Commit also updates how the stac-catalog url is inferred for a stac-browser deployment. Stac browser deployment is not currently implemented in GHGC backend.

# Issue
https://github.com/NASA-IMPACT/veda-backend/issues/343