### PR TITLE
Upgrade rio tiler version and expose 3rd libraries version numbers

### DIFF
--- a/raster_api/runtime/setup.py
+++ b/raster_api/runtime/setup.py
@@ -7,6 +7,7 @@ with open("README.md") as f:
 
 inst_reqs = [
     "boto3",
+    "rio-tiler==6.5.0",
     "titiler.pgstac==0.8.3",
     "titiler.core>=0.15.5,<0.16",
     "titiler.mosaic>=0.15.5,<0.16",
@@ -15,7 +16,7 @@ inst_reqs = [
     "aws_xray_sdk>=2.6.0,<3",
     "aws-lambda-powertools>=1.18.0",
     "python-multipart==0.0.7",
-    "rio-tiler==6.4.4",
+
 ]
 
 extra_reqs = {

--- a/raster_api/runtime/setup.py
+++ b/raster_api/runtime/setup.py
@@ -16,7 +16,6 @@ inst_reqs = [
     "aws_xray_sdk>=2.6.0,<3",
     "aws-lambda-powertools>=1.18.0",
     "python-multipart==0.0.7",
-
 ]
 
 extra_reqs = {

--- a/raster_api/runtime/src/app.py
+++ b/raster_api/runtime/src/app.py
@@ -128,19 +128,15 @@ def ping():
     return {"ping": "pong!!"}
 
 
-@app.get("/versions", description="Get Python library versions", tags=["Version"])
+@app.get("/versions", description="Get used Python library versions", tags=["Versions"])
 def versions():
     """Versions check."""
-    import rio_tiler as tr
+    import pkg_resources
 
-    import starlette as stlt
-    import titiler.pgstac as tgst
-
-    return {
-        "rio_tiler": tr.__version__,
-        "starlette": stlt.__version__,
-        "titiler-pgstac": tgst.__version__,
-    }
+    pkg_versions = {}
+    for element in pkg_resources.working_set:
+        pkg_versions[element.key] = element.version
+    return pkg_versions
 
 
 # Add support for non-default projections

--- a/stac_api/runtime/src/app.py
+++ b/stac_api/runtime/src/app.py
@@ -71,6 +71,17 @@ if tiles_settings.titiler_endpoint:
     extension.register(api.app, tiles_settings.titiler_endpoint)
 
 
+@app.get("/versions", description="Get used Python library versions", tags=["Versions"])
+def versions():
+    """Versions check."""
+    import pkg_resources
+
+    pkg_versions = {}
+    for element in pkg_resources.working_set:
+        pkg_versions[element.key] = element.version
+    return pkg_versions
+
+
 @app.get("/index.html", response_class=HTMLResponse)
 async def viewer_page(request: Request):
     """Search viewer."""


### PR DESCRIPTION
This PR fixes this [issue](https://github.com/US-GHG-Center/ghgc-architecture/issues/212)
Also we added a path to expose what versions raster and stac-api are currently using 